### PR TITLE
Remove duplicated react-native-cookies

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -1070,11 +1070,6 @@
     "android": true
   },
   {
-    "githubUrl": "https://github.com/joeferraro/react-native-cookies",
-    "ios": true,
-    "android": true
-  },
-  {
     "githubUrl": "https://github.com/innoveit/react-native-ble-manager",
     "ios": true,
     "android": true


### PR DESCRIPTION
Duplicated from lines https://github.com/expo/react-native-libraries/blob/master/react-native-libraries.json#L242-L245

Sorry about noisy PR, this is the last duplicated. (Before we have CI for auto check)